### PR TITLE
feat: Add workshop-pages-theme for GitHub Pages

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,45 @@
+name: Deploy Jekyll site to Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,28 @@
+remote_theme: shinyay/workshop-pages-theme
+title: "Getting Started with Copilot CLI"
+description: "A progressive 8-level curriculum for mastering GitHub Copilot CLI — from first launch to advanced automation and delegation. 96 exercises across 9-13 hours."
+author: "shinyay"
+
+plugins:
+  - jekyll-remote-theme
+
+workshop:
+  category: "copilot-ai"
+  language: "Python"
+  difficulty: "Beginner"
+  duration: "9-13 hours"
+  prerequisites:
+    - "GitHub Copilot subscription (Individual, Business, or Enterprise)"
+    - "Node.js 22 or later"
+    - "Git installed and configured"
+    - "Terminal (macOS/Linux) or PowerShell 6+ (Windows)"
+  hub_url: "https://shinyay.github.io/awesome-shinyay-workshop/"
+  show_toc: true
+  show_progress: true
+
+# Default front matter
+defaults:
+  - scope:
+      path: ""
+    values:
+      layout: "workshop"

--- a/index.md
+++ b/index.md
@@ -1,0 +1,40 @@
+---
+layout: workshop
+---
+
+## 🎓 Workshop Overview
+
+A progressive **8-level curriculum** for mastering GitHub Copilot CLI, from first launch to advanced automation and delegation.
+
+```
+Level 1   Level 2    Level 3    Level 4    Level 5    Level 6     Level 7      Level 8
+Observe → Understand → Plan → Create → Execute → Workflow → Customize → Advanced
+  🟢        🟢         🟢      🟡       🟡        🟠         🟢          🔴
+```
+
+## Curriculum
+
+| Level | Title | Exercises | Time |
+|-------|-------|:---------:|------|
+| [**1**](steps/1/) | Observe — Read-Only Exploration | 12 | 45–60 min |
+| [**2**](steps/2/) | Understand — Ask Questions | 12 | 60–80 min |
+| [**3**](steps/3/) | Plan — Think Before Acting | 12 | 60–80 min |
+| [**4**](steps/4/) | Create — Make Your First Changes | 12 | 60–90 min |
+| [**5**](steps/5/) | Execute — Run Commands | 12 | 75–100 min |
+| [**6**](steps/6/) | Workflow — Full Cycle | 12 | 90–120 min |
+| [**7**](steps/7/) | Customize — Make It Yours | 12 | 75–100 min |
+| [**8**](steps/8/) | Advanced — Delegation | 12 | 90–120 min |
+
+**Total: 96 exercises across 8 levels**
+
+## What is Copilot CLI?
+
+Copilot CLI is a **terminal-based AI agent** that operates directly in your development environment. It can read your codebase, run commands, edit files, and interact with GitHub — all from the command line.
+
+## Key Characteristics
+
+- 🖥️ **Cross-platform** — Linux, macOS, and Windows support
+- 🎯 **Interactive UI** — Rich terminal interface with tool approval
+- 📝 **Editor-agnostic** — Works alongside any editor or IDE
+- 🔗 **GitHub integration** — Native access to issues, PRs, and repos
+- 🔌 **Extensible** — MCP servers for custom tool integration

--- a/workshop/level-1/README.md
+++ b/workshop/level-1/README.md
@@ -1,3 +1,10 @@
+---
+layout: step
+title: "Level 1: Observe — Read-Only Exploration (No Risk)"
+step_number: 1
+permalink: /steps/1/
+---
+
 # Level 1: Observe — Read-Only Exploration (No Risk)
 
 > **Risk level:** 🟢 Zero — Nothing in this level modifies any files.

--- a/workshop/level-2/README.md
+++ b/workshop/level-2/README.md
@@ -1,3 +1,10 @@
+---
+layout: step
+title: "Level 2: Understand — Ask Questions & Get Explanations"
+step_number: 2
+permalink: /steps/2/
+---
+
 # Level 2: Understand — Ask Questions & Get Explanations
 
 > **Risk level:** 🟢 Zero — Nothing in this level modifies any files. You are still read-only.

--- a/workshop/level-3/README.md
+++ b/workshop/level-3/README.md
@@ -1,3 +1,10 @@
+---
+layout: step
+title: "Level 3: Plan — Think Before Acting"
+step_number: 3
+permalink: /steps/3/
+---
+
 # Level 3: Plan — Think Before Acting
 
 > **Risk level:** 🟢 Zero — Plans don't modify files. You create, review, refine, and reject plans without any code being written.

--- a/workshop/level-4/README.md
+++ b/workshop/level-4/README.md
@@ -1,3 +1,10 @@
+---
+layout: step
+title: "Level 4: Create — Make Your First Changes"
+step_number: 4
+permalink: /steps/4/
+---
+
 # Level 4: Create — Make Your First Changes
 
 > **Risk level:** 🟡 Low — You will modify files for the first time. All changes are to workshop sample code and can be reverted with `git checkout`.

--- a/workshop/level-5/README.md
+++ b/workshop/level-5/README.md
@@ -1,3 +1,10 @@
+---
+layout: step
+title: "Level 5: Execute — Run Commands Through Copilot"
+step_number: 5
+permalink: /steps/5/
+---
+
 # Level 5: Execute — Run Commands Through Copilot
 
 > **Risk level:** 🟡 Medium — Copilot will run shell commands (tests, linters, scripts) on your behalf. Always read `bash` tool invocations before approving.

--- a/workshop/level-6/README.md
+++ b/workshop/level-6/README.md
@@ -1,3 +1,10 @@
+---
+layout: step
+title: "Level 6: Workflow — The Full Plan → Execute → Review Cycle"
+step_number: 6
+permalink: /steps/6/
+---
+
 # Level 6: Workflow — The Full Plan → Execute → Review Cycle
 
 > **Risk level:** 🟠 Medium — You will perform complete development workflows: building features, fixing multi-file bugs, refactoring, writing tests, and updating documentation — all through Copilot.

--- a/workshop/level-7/README.md
+++ b/workshop/level-7/README.md
@@ -1,3 +1,10 @@
+---
+layout: step
+title: "Level 7: Customize — Make Copilot Work Your Way"
+step_number: 7
+permalink: /steps/7/
+---
+
 # Level 7: Customize — Make Copilot Work Your Way
 
 > **Risk level:** 🟢 Low — You are configuring Copilot's behavior, not modifying production code. All configurations are additive and reversible.

--- a/workshop/level-8/README.md
+++ b/workshop/level-8/README.md
@@ -1,3 +1,10 @@
+---
+layout: step
+title: "Level 8: Advanced — Permissions, Sessions & Delegation"
+step_number: 8
+permalink: /steps/8/
+---
+
 # Level 8: Advanced — Permissions, Sessions & Delegation
 
 > **Risk level:** 🔴 High awareness required — You will work with fine-grained permissions, security-sensitive files, automation scripts, and delegation to autonomous agents. Understanding what you authorize is critical.


### PR DESCRIPTION
## Summary

Integrates the `workshop-pages-theme` Jekyll remote theme to provide a branded documentation site with:

- 🎨 **GitHub Branding** — Primer CSS + official brand colors (dark/light mode)
- 📋 **Step Navigation** — Auto-discovered 8-level sidebar with progress bar
- ⬅️➡️ **Prev/Next** — Navigate between workshop levels
- 📑 **Auto TOC** — Table of contents from headings
- 🏷️ **Workshop Badges** — Difficulty, language, duration, step count
- 🏠 **Hub Link** — Links back to Workshop Hub
- 📱 **Responsive** — Desktop sidebar, mobile slide-out

### Files Added
- `_config.yml` — Workshop metadata & theme configuration
- `index.md` — Workshop overview page
- `.github/workflows/deploy-pages.yml` — Auto-deploy to Pages

### Files Modified
- `workshop/level-{1..8}/README.md` — Added Jekyll front matter for step discovery

### Preview
After merge, the site will be live at:
https://shinyay.github.io/getting-started-with-copilot-cli-v0.0.411/